### PR TITLE
Also show counters with neutral karma

### DIFF
--- a/karmaplugin.cpp
+++ b/karmaplugin.cpp
@@ -125,7 +125,7 @@ void KarmaPlugin::newEvent(DaZeus::Event *e) {
 			if(!d->error().isNull()) {
 				qWarning() << "Failed to fetch karma: " << d->error();
 			}
-			res = d->message(network, recv, object + " has neutral karma.");
+			res = d->message(network, recv, object + " has neutral karma (+" + QString::number(currUp) + ", -" + QString::number(currDown) + ").");
 		} else {
 			res = d->message(network, recv, object + " has a karma of " + QString::number(current) + " (+" + QString::number(currUp) + ", -" + QString::number(currDown) + ").");
 		}


### PR DESCRIPTION
```
<mrngm> }karma blaat
<dazeusje> blaat has a karma of -1 (+3, -4).
<mrngm> }karma doetniet
<dazeusje> doetniet has neutral karma. (+0, -0).
<mrngm> }karma doetniet
<dazeusje> doetniet has neutral karma (+0, -0).
<mrngm> blaat++
<mrngm> }karma blaat
<dazeusje> blaat has neutral karma (+4, -4).
```

On line 4 there is a stray dot. It has been removed, as can be seen on line 6.
